### PR TITLE
Add `test` script to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "keywords": ["api", "api-client", "docs", "docs-api", "helpscout"],
     "homepage": "http://www.helpscout.net",
     "license": "MIT",
+    "scripts": {
+        "test": "phpunit"
+    },
     "authors": [
         {
             "name": "Help Scout",


### PR DESCRIPTION
Composer gives us the possibility to define scripts in the `composer.json` file: [Documentation on getcomposer.org](https://getcomposer.org/doc/articles/scripts.md)

Most libraries now define a `test` script which makes running unit tests as easy as executing `composer test`.

Here is more on the topic:
- http://maxgfeller.com/blog/2014/07/22/composer-test/
- https://pantheon.io/blog/writing-composer-scripts