### PR TITLE
Allow `collectionId` param

### DIFF
--- a/src/HelpScoutDocs/Api/AbstractApi.php
+++ b/src/HelpScoutDocs/Api/AbstractApi.php
@@ -212,7 +212,7 @@ abstract class AbstractApi
      */
     protected function getParams(array $params = [])
     {
-        $accepted = ['page', 'sort', 'order', 'status', 'query', 'visibility'];
+        $accepted = ['page', 'sort', 'order', 'status', 'query', 'visibility', 'collectionId'];
 
         if (!$params) {
             return [];


### PR DESCRIPTION
The methods accept a collection ID, but it's stripped at this point.