### PR TITLE
Added pageSize support for Articles List endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Docs API Client Endpoints Methods
 * deleteCategory($categoryId)
 
 ### Articles
-* getArticles($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = 50)
+* ~~getArticles($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = 50)~~ Deprecated. Will be removed soon.
+* getArticlesForCategory($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = 50)
+* getArticlesForCollection($collectionId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = 50)
 * searchArticles($query = '*', $page = 1, $collectionId = '', $status = 'all', $visibility = 'all')
 * getRelatedArticles($articleId, $page = 1, $status = 'all', $sort = 'order', $order = 'desc')
 * getRevisions($articleId, $page = 1)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Docs API Client Endpoints Methods
 * deleteCategory($categoryId)
 
 ### Articles
-* getArticles($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc')
+* getArticles($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = 50)
 * searchArticles($query = '*', $page = 1, $collectionId = '', $status = 'all', $visibility = 'all')
 * getRelatedArticles($articleId, $page = 1, $status = 'all', $sort = 'order', $order = 'desc')
 * getRevisions($articleId, $page = 1)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+TODO:
+=====
+
+1. Improve models serialization / deserialization
+2. Release version for php 7.1+

--- a/examples/basic.php
+++ b/examples/basic.php
@@ -15,7 +15,7 @@ $collections = $docsApiClient->getCollections();
 $helpCategories = $docsApiClient->getCategories('COLLECTION_ID');
 
 // Get all articles by category ID
-$helpCategoryArticles = $docsApiClient->getArticles('CATEGORY_ID');
+$helpCategoryArticles = $docsApiClient->getArticlesForCategory('CATEGORY_ID');
 
 // Get all sites
 $sites = $docsApiClient->getSites();

--- a/src/HelpScoutDocs/Api/AbstractApi.php
+++ b/src/HelpScoutDocs/Api/AbstractApi.php
@@ -22,7 +22,7 @@ abstract class AbstractApi
     /**
      * @param $url
      * @param array $params
-     * @return array
+     * @return string
      * @throws ApiException
      */
     protected function get($url, array $params)
@@ -50,9 +50,8 @@ abstract class AbstractApi
         }
 
         $this->client->setLastResponse($response);
-        $content = $response->getBody()->getContents();
 
-        return $content;
+        return $response->getBody()->getContents();
     }
 
     /**
@@ -212,20 +211,31 @@ abstract class AbstractApi
      */
     protected function getParams(array $params = [])
     {
-        $accepted = ['page', 'sort', 'order', 'status', 'query', 'visibility', 'collectionId'];
+        //TODO: Move to const array after PHP 5.5 support drop
+        $accepted = [
+            'page',
+            'sort',
+            'order',
+            'status',
+            'query',
+            'visibility',
+            'collectionId',
+            'pageSize'
+        ];
 
         if (!$params) {
             return [];
         }
         foreach($params as $key => $val) {
             $key = trim($key);
-            if (!in_array($key, $accepted) || empty($params[$key])) {
+            if (empty($params[$key]) || !in_array($key, $accepted, true)) {
                 unset($params[$key]);
                 continue;
             }
             switch($key) {
                 case 'page':
-                    $val = intval($val);
+                case 'pageSize':
+                    $val = (int)$val;
                     if ($val < 1) {
                         unset($params[$key]);
                     }
@@ -263,7 +273,7 @@ abstract class AbstractApi
 
     /**
      * @param string $url
-     * @param string $params
+     * @param array $params
      * @param string $modelClass
      * @return ResourceCollection|mixed
      * @throws ApiException

--- a/src/HelpScoutDocs/Api/Article.php
+++ b/src/HelpScoutDocs/Api/Article.php
@@ -19,6 +19,8 @@ class Article extends AbstractApi
      * @param int $pageSize
      * @return bool|ResourceCollection
      * @throws ApiException
+     *
+     * @deprecated
      */
     public function all(
         $categoryId,
@@ -28,16 +30,83 @@ class Article extends AbstractApi
         $order = 'asc',
         $pageSize = self::DEFAULT_PAGE_SIZE
     ) {
+        return $this->allForCategory(
+            $categoryId,
+            $page,
+            $status,
+            $sort,
+            $order,
+            $pageSize
+        );
+    }
+
+    /**
+     * @param $categoryId
+     * @param int $page
+     * @param string $status
+     * @param string $sort
+     * @param string $order
+     * @param int $pageSize
+     * @return ResourceCollection|mixed
+     * @throws ApiException
+     */
+    public function allForCategory(
+        $categoryId,
+        $page = 1,
+        $status = 'all',
+        $sort = 'order',
+        $order = 'asc',
+        $pageSize = self::DEFAULT_PAGE_SIZE
+    ) {
         $params = [
             'page'   => $page,
-            'status' => $status,
             'sort'   => $sort,
             'order'  => $order,
             'pageSize' => $pageSize
         ];
 
+        if ($status !== 'all') {
+            $params['status'] = $status;
+        }
+
         return $this->getResourceCollection(
             sprintf("categories/%s/articles", $categoryId),
+            $this->getParams($params),
+            Models\ArticleRef::class
+        );
+    }
+
+    /**
+     * @param $collectionId
+     * @param int $page
+     * @param string $status
+     * @param string $sort
+     * @param string $order
+     * @param int $pageSize
+     * @return ResourceCollection|mixed
+     * @throws ApiException
+     */
+    public function allForCollection(
+        $collectionId,
+        $page = 1,
+        $status = 'all',
+        $sort = 'order',
+        $order = 'asc',
+        $pageSize = self::DEFAULT_PAGE_SIZE
+    ) {
+        $params = [
+            'page'   => $page,
+            'sort'   => $sort,
+            'order'  => $order,
+            'pageSize' => $pageSize
+        ];
+
+        if ($status !== 'all') {
+            $params['status'] = $status;
+        }
+
+        return $this->getResourceCollection(
+            sprintf("collections/%s/articles", $collectionId),
             $this->getParams($params),
             Models\ArticleRef::class
         );
@@ -57,9 +126,12 @@ class Article extends AbstractApi
             'query'        => $query,
             'page'         => $page,
             'collectionId' => $collectionId,
-            'status'       => $status,
             'visibility'   => $visibility
         ];
+
+        if ($status !== 'all') {
+            $params['status'] = $status;
+        }
 
         return $this->getResourceCollection(
             "search/articles",
@@ -80,10 +152,13 @@ class Article extends AbstractApi
     {
         $params = [
             'page'   => $page,
-            'status' => $status,
             'sort'   => $sort,
             'order'  => $order
         ];
+
+        if ($status !== 'all') {
+            $params['status'] = $status;
+        }
 
         return $this->getResourceCollection(
             sprintf("articles/%s/related", $articleId),

--- a/src/HelpScoutDocs/Api/Article.php
+++ b/src/HelpScoutDocs/Api/Article.php
@@ -8,21 +8,32 @@ use HelpScoutDocs\ResourceCollection;
 
 class Article extends AbstractApi
 {
+    const DEFAULT_PAGE_SIZE = 50;
+
     /**
      * @param $categoryId
      * @param int $page
      * @param string $status
      * @param string $sort
      * @param string $order
+     * @param int $pageSize
      * @return bool|ResourceCollection
+     * @throws ApiException
      */
-    public function all($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc')
-    {
+    public function all(
+        $categoryId,
+        $page = 1,
+        $status = 'all',
+        $sort = 'order',
+        $order = 'asc',
+        $pageSize = self::DEFAULT_PAGE_SIZE
+    ) {
         $params = [
             'page'   => $page,
             'status' => $status,
             'sort'   => $sort,
-            'order'  => $order
+            'order'  => $order,
+            'pageSize' => $pageSize
         ];
 
         return $this->getResourceCollection(

--- a/src/HelpScoutDocs/DocsApiClient.php
+++ b/src/HelpScoutDocs/DocsApiClient.php
@@ -163,10 +163,42 @@ class DocsApiClient {
      * @param int $pageSize
      * @return bool|ResourceCollection
      * @throws ApiException
+     *
+     * @deprecated
      */
     public function getArticles($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = Article::DEFAULT_PAGE_SIZE)
     {
         return $this->articles()->all($categoryId, $page, $status, $sort, $order, $pageSize);
+    }
+
+    /**
+     * @param $categoryId
+     * @param int $page
+     * @param string $status
+     * @param string $sort
+     * @param string $order
+     * @param int $pageSize
+     * @return ResourceCollection|mixed
+     * @throws ApiException
+     */
+    public function getArticlesForCategory($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = Article::DEFAULT_PAGE_SIZE)
+    {
+        return $this->articles()->allForCategory($categoryId, $page, $status, $sort, $order, $pageSize);
+    }
+
+    /**
+     * @param $collectionId
+     * @param int $page
+     * @param string $status
+     * @param string $sort
+     * @param string $order
+     * @param int $pageSize
+     * @return ResourceCollection|mixed
+     * @throws ApiException
+     */
+    public function getArticlesForCollection($collectionId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = Article::DEFAULT_PAGE_SIZE)
+    {
+        return $this->articles()->allForCollection($collectionId, $page, $status, $sort, $order, $pageSize);
     }
 
     /**

--- a/src/HelpScoutDocs/DocsApiClient.php
+++ b/src/HelpScoutDocs/DocsApiClient.php
@@ -4,6 +4,7 @@ namespace HelpScoutDocs;
 
 use BadMethodCallException;
 use GuzzleHttp\Client;
+use HelpScoutDocs\Api\Article;
 use InvalidArgumentException;
 use HelpScoutDocs\Models;
 
@@ -159,11 +160,13 @@ class DocsApiClient {
      * @param string $status
      * @param string $sort
      * @param string $order
+     * @param int $pageSize
      * @return bool|ResourceCollection
+     * @throws ApiException
      */
-    public function getArticles($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc')
+    public function getArticles($categoryId, $page = 1, $status = 'all', $sort = 'order', $order = 'asc', $pageSize = Article::DEFAULT_PAGE_SIZE)
     {
-        return $this->articles()->all($categoryId, $page, $status, $sort, $order);
+        return $this->articles()->all($categoryId, $page, $status, $sort, $order, $pageSize);
     }
 
     /**

--- a/tests/HelpScoutDocs/Endpoints/ArticlesTest.php
+++ b/tests/HelpScoutDocs/Endpoints/ArticlesTest.php
@@ -297,4 +297,30 @@ class ArticlesTest extends TestCase
 
         $apiClient->deleteArticleDraft(uniqid());
     }
+
+    /**
+     * @test
+     */
+    public function should_return_articles_for_category()
+    {
+        $responseMock = $this->createResponseMock(200, __DIR__ . '/../../fixtures/articles/articles.json');
+        $apiClient = $this->createTestApiClient($responseMock);
+
+        $articles = $apiClient->getArticlesForCategory(uniqid());
+
+        $this->assertInstanceOf(ResourceCollection::class, $articles);
+    }
+
+    /**
+     * @test
+     */
+    public function should_return_articles_for_collection()
+    {
+        $responseMock = $this->createResponseMock(200, __DIR__ . '/../../fixtures/articles/articles.json');
+        $apiClient = $this->createTestApiClient($responseMock);
+
+        $articles = $apiClient->getArticlesForCollection(uniqid());
+
+        $this->assertInstanceOf(ResourceCollection::class, $articles);
+    }
 }


### PR DESCRIPTION
- Added pageSize support for Articles List endpoint
- Added separate methods for retrieving articles per collection and per category
- Deprecated getArticles endpoint

Related Issue: https://github.com/m1x0n/helpscout-docs-api-php/issues/10