### PR TITLE
Get use of provided article name on upload.

### DIFF
--- a/src/HelpScoutDocs/Api/Article.php
+++ b/src/HelpScoutDocs/Api/Article.php
@@ -297,6 +297,10 @@ class Article extends AbstractApi
                 'contents' => $uploadArticle->getCategoryId()
             ],
             [
+                'name' => 'name',
+                'contents' => $uploadArticle->getName()
+            ],
+            [
                 'name' => 'slug',
                 'contents' => $uploadArticle->getSlug()
             ],


### PR DESCRIPTION
Previously such parameter as `name` was ignored for article upload.
Thus article's name was exposed from file's name.
Now it should be possible to customize it via `setName()` on `UploadArticle`.

This should solve https://github.com/m1x0n/helpscout-docs-api-php/issues/15
